### PR TITLE
fix undefined model after clicking toolbar buttons

### DIFF
--- a/src/tinymce.component.ts
+++ b/src/tinymce.component.ts
@@ -203,7 +203,7 @@ export class TinyMceComponent implements ControlValueAccessor, AfterViewInit, On
         this.ngZone.run(() => {
           const content = this.editor.getContent();
           if (content != null && content.length > 0) {
-            this.onModelChange();
+            this.onModelChange(content);
             this.onModelTouched();
           }
         });


### PR DESCRIPTION
Clicking a toolbar button will set the model value to `undefined` until you hit the next key. This was clearly a bug.